### PR TITLE
refactor: split bridge message handling and add show_discord_channel_name

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+lib/
+*.tsbuildinfo
+tsconfig.temp.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.DS_Store
+tsconfig.tsbuildinfo
+.github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ### ✨ Features
-- [Config] 新增了 `show_discord_avatar` 用于控制转发消息时是否携带用户的 Discord 头像（默认开启）
-- [Config] 新增了 `sync_edit_delete` 用于控制是否同步 Discord 侧编辑 / 删除消息事件到 QQ 侧（默认关闭）
+- [Config] 新增了 `show_discord_channel_name` 用于控制转发消息到 QQ 时是否显示 Discord 的频道名称（默认关闭）
 
 ### 🐞 Bug Fixes
 - None

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![npm](https://img.shields.io/npm/v/koishi-plugin-bridge-qq-discord)](https://www.npmjs.com/package/koishi-plugin-bridge-qq-discord)
 [![LICENSE](https://img.shields.io/github/license/Cola-Ace/koishi-plugin-bridge-qq-discord)](https://github.com/Cola-Ace/koishi-plugin-bridge-qq-discord/blob/main/LICENSE)
 ![NPM Downloads](https://img.shields.io/npm/d18m/koishi-plugin-bridge-qq-discord)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Cola-Ace/koishi-plugin-bridge-discord-qq/publish.yml)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Cola-Ace/koishi-plugin-bridge-qq-discord/publish.yml)
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-bridge-qq-discord",
   "description": "自用插件，如需进一步了解请联系我（联系方式见 Github）",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "contributors": [
     "Xc_ace <xca259@gmail.com>"
   ],

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,0 +1,126 @@
+import { Bot, Context, h } from "koishi";
+import sharp from "sharp";
+import { BasicType, Config } from "./config";
+import { getBinary, logger } from "./utils";
+
+export interface BridgeRoute {
+  from: BasicType;
+  to: BasicType;
+}
+
+export interface BridgeMessageRecord {
+  fromMessageId: string;
+  fromPlatform: string;
+  fromChannelId: string;
+  fromSenderId: string;
+  fromSenderName: string;
+  toMessageId: string;
+  toPlatform: string;
+  toChannelId: string;
+  onebotRealMessageId: string;
+}
+
+export function findBridgeRoutes(config: Config, platform: string, selfId: string, channelId: string): BridgeRoute[] {
+  const routes: BridgeRoute[] = [];
+
+  for (const constant of config.constant ?? []) {
+    if (!constant.enable) continue;
+
+    for (const from of constant.from) {
+      if (from.platform !== platform || from.self_id !== selfId || from.channel_id !== channelId) continue;
+
+      for (const to of constant.to) {
+        routes.push({ from, to });
+      }
+    }
+  }
+
+  return routes;
+}
+
+export async function createBridgeMessageRecord(ctx: Context, record: BridgeMessageRecord) {
+  const fromGuild = await ctx.database.get("channel", {
+    id: record.fromChannelId,
+  });
+  const toGuild = await ctx.database.get("channel", {
+    id: record.toChannelId,
+  });
+
+  await ctx.database.create("bridge_message", {
+    timestamp: BigInt(Date.now()),
+    from_message_id: record.fromMessageId,
+    from_platform: record.fromPlatform,
+    from_channel_id: record.fromChannelId,
+    from_guild_id: fromGuild[0]["guildId"],
+    from_sender_id: record.fromSenderId,
+    from_sender_name: record.fromSenderName,
+    to_message_id: record.toMessageId,
+    to_platform: record.toPlatform,
+    to_channel_id: record.toChannelId,
+    to_guild_id: toGuild[0]["guildId"],
+    onebot_real_message_id: record.onebotRealMessageId,
+  });
+}
+
+export async function sendQQMessageWithRetry(qqbot: Bot, channelId: string, message: string, maxAttempts = 3): Promise<string[] | null> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await qqbot.sendMessage(channelId, message);
+    } catch (error) {
+      if (attempt >= maxAttempts) {
+        logger.error(error);
+        return null;
+      }
+
+      logger.info(`发送消息失败，正在重试... (${attempt}/${maxAttempts})`);
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
+
+  return null;
+}
+
+export function getDiscordAvatarUrl(config: Config, avatarUrl: string | null, fallbackUrl: string): string {
+  if (avatarUrl !== null) return fallbackUrl;
+
+  let avatarColor = config.discord_default_avatar_color.toString();
+  if (config.discord_default_avatar_color === 99) {
+    avatarColor = Math.floor(Math.random() * 5).toString();
+  }
+
+  return `https://cdn.discordapp.com/embed/avatars/${avatarColor}.png`;
+}
+
+export async function createDiscordAvatarElement(ctx: Context, config: Config, avatar: string): Promise<any> {
+  if (!config.show_discord_avatar) return "";
+  if (config.file_processor !== "Koishi") return h.image(avatar);
+
+  const [avatarBlob, avatarType, avatarError] = await getBinary(avatar, ctx.http);
+  if (avatarError) {
+    logger.error(avatarError);
+    return null;
+  }
+
+  const avatarArrayBuffer = await avatarBlob.arrayBuffer();
+  const resizedAvatar = await sharp(avatarArrayBuffer).resize(64, 64).toBuffer();
+
+  return h.image(resizedAvatar, avatarType);
+}
+
+export function findDiscordToQQBot(ctx: Context, config: Config, fromChannelId: string, toChannelId: string): Bot | null {
+  for (const constant of config.constant ?? []) {
+    if (!constant.enable) continue;
+
+    for (const from of constant.from) {
+      if (from.platform !== "discord" || from.channel_id !== fromChannelId) continue;
+
+      for (const to of constant.to) {
+        if (to.platform === "onebot" && to.channel_id === toChannelId) {
+          return ctx.bots[`${to.platform}:${to.self_id}`];
+        }
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -46,18 +46,23 @@ export async function createBridgeMessageRecord(ctx: Context, record: BridgeMess
     id: record.toChannelId,
   });
 
+  const fromGuildId = fromGuild[0]?.guildId ?? "";
+  const toGuildId = toGuild[0]?.guildId ?? "";
+  if (!fromGuild[0]) logger.warn(`Failed to find guild for channel ${record.fromChannelId}`);
+  if (!toGuild[0]) logger.warn(`Failed to find guild for channel ${record.toChannelId}`);
+
   await ctx.database.create("bridge_message", {
     timestamp: BigInt(Date.now()),
     from_message_id: record.fromMessageId,
     from_platform: record.fromPlatform,
     from_channel_id: record.fromChannelId,
-    from_guild_id: fromGuild[0]["guildId"],
+    from_guild_id: fromGuildId,
     from_sender_id: record.fromSenderId,
     from_sender_name: record.fromSenderName,
     to_message_id: record.toMessageId,
     to_platform: record.toPlatform,
     to_channel_id: record.toChannelId,
-    to_guild_id: toGuild[0]["guildId"],
+    to_guild_id: toGuildId,
     onebot_real_message_id: record.onebotRealMessageId,
   });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export interface Config {
   file_processor: "Koishi" | "QQBot",
   show_discord_avatar: boolean,
   sync_edit_delete: boolean,
+  show_discord_channel_name: boolean,
   discord_default_avatar_color: 99 | 0 | 1 | 2 | 3 | 4,
   download_threads: number,
   qq_file_limit: number,
@@ -59,6 +60,7 @@ export const Config: Schema<Config> = Schema.object({
 
   show_discord_avatar: Schema.boolean().description("显示 Discord 头像").default(true),
   sync_edit_delete: Schema.boolean().description("同步消息的编辑和删除").default(false),
+  show_discord_channel_name: Schema.boolean().description("转发消息到 QQ 时显示 Discord 的频道名称").default(false),
 
   discord_default_avatar_color: Schema.union([
     Schema.const(99).description("随机颜色"),

--- a/src/discord/message/delete.ts
+++ b/src/discord/message/delete.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { Context } from "koishi";
 import type { Session } from "koishi";
+import { findDiscordToQQBot } from "../../bridge";
 import { Config } from "../../config";
 
 export default async function onDiscordMessageDeleted(ctx: Context, config: Config, session: Session) {
@@ -18,22 +19,9 @@ export default async function onDiscordMessageDeleted(ctx: Context, config: Conf
 
   // If not found, maybe it's a message that was sent before the bot was added to the channel,
   // or the message was not bridged for some reason (for example have words in the blacklist). In this case, we can just ignore the deletion.
-  if (!bridgeMessage) return;
+  if (bridgeMessage.length === 0) return;
 
-  let qqbot = null;
-  for (const constant of config.constant || []) {
-    if (
-      constant.enable &&
-      constant.from[0].platform === "discord" &&
-      constant.from[0].channel_id === channelId &&
-      constant.to[0].platform === "onebot" &&
-      constant.to[0].channel_id === bridgeMessage[0].to_channel_id
-    ) {
-      qqbot = ctx.bots[`${constant.to[0].platform}:${constant.to[0].self_id}`];
-      break;
-    }
-  }
-
+  const qqbot = findDiscordToQQBot(ctx, config, channelId, bridgeMessage[0].to_channel_id);
   if (!qqbot) return;
 
   // Delete message

--- a/src/discord/message/update.ts
+++ b/src/discord/message/update.ts
@@ -1,9 +1,9 @@
 // @ts-nocheck
-import { Context, h } from "koishi";
+import { Context } from "koishi";
 import type { Session } from "koishi";
-import { getBinary, logger, BlacklistDetector } from "../../utils";
+import { createDiscordAvatarElement, findDiscordToQQBot, getDiscordAvatarUrl, sendQQMessageWithRetry } from "../../bridge";
+import { logger, BlacklistDetector } from "../../utils";
 import { Config } from "../../config";
-import sharp from "sharp";
 
 export default async function onDiscordMessageUpdated(ctx: Context, config: Config, session: Session) {
 	if (!config.sync_edit_delete) return;
@@ -28,22 +28,9 @@ export default async function onDiscordMessageUpdated(ctx: Context, config: Conf
 
 	// If not found, maybe it's a message that was sent before the bot was added to the channel,
 	// or the message was not bridged for some reason (for example have words in the blacklist). In this case, we can just ignore the update.
-	if (!bridgeMessage) return;
+	if (bridgeMessage.length === 0) return;
 
-	let qqbot = null;
-	for (const constant of config.constant || []) {
-		if (
-			constant.enable &&
-			constant.from[0].platform === "discord" &&
-			constant.from[0].channel_id === channelId &&
-			constant.to[0].platform === "onebot" &&
-			constant.to[0].channel_id === bridgeMessage[0].to_channel_id
-		) {
-			qqbot = ctx.bots[`${constant.to[0].platform}:${constant.to[0].self_id}`];
-			break;
-		}
-	}
-
+	const qqbot = findDiscordToQQBot(ctx, config, channelId, bridgeMessage[0].to_channel_id);
 	if (!qqbot) return;
 
 	// Delete message
@@ -58,56 +45,28 @@ export default async function onDiscordMessageUpdated(ctx: Context, config: Conf
 	// Init nickname
 	const nickname = session.member.nick === null ? session.author.global_name : session.member.nick;
 
-	// Process Discord default avatar
-	let avatar_color = "";
-	let avatar = `https://cdn.discordapp.com/avatars/${session.author.id}/${session.author.avatar ?? ""}.png?size=64`;
-	if (session.author.avatar === null) {
-		avatar_color = config.discord_default_avatar_color.toString();
-		if (config.discord_default_avatar_color === 99) {
-			avatar_color = Math.floor(Math.random() * 5).toString();
-		}
-		avatar = `https://cdn.discordapp.com/embed/avatars/${avatar_color}.png`;
-	}
-
-	let message_content = `${config.show_discord_avatar ? h.image(avatar) : ""}[Discord] ${nickname}:\n===== 该条消息为 Discord 编辑后消息 =====\n${content}`;
-	if (config.file_processor === "Koishi") {
-		const [avatar_blob, avatar_type, avatar_error] = await getBinary(avatar, ctx.http);
-		if (avatar_error) {
-			logger.error(avatar_error);
-			return;
-		}
-		const avatar_arrayBuffer = await avatar_blob.arrayBuffer();
-		const avatar_resize_arrayBuffer = await sharp(avatar_arrayBuffer).resize(64, 64).toBuffer();
-		message_content = `${config.show_discord_avatar ? h.image(avatar_resize_arrayBuffer, avatar_type) : ""}[Discord] ${nickname}:\n===== 该条消息为 Discord 编辑后消息 =====\n${content}`;
-	}
+	const avatar = getDiscordAvatarUrl(
+		config,
+		session.author.avatar,
+		`https://cdn.discordapp.com/avatars/${session.author.id}/${session.author.avatar ?? ""}.png?size=64`,
+	);
+	const avatarElement = await createDiscordAvatarElement(ctx, config, avatar);
+	if (avatarElement === null) return;
 
 	// Send Message
-	let retry_count = 0;
-	while (retry_count <= 3) {
-		try {
-			const newMessageId = await qqbot.sendMessage(bridgeMessage[0].to_channel_id, message_content);
-			// Record the message mapping in the database after the message is sent successfully
-			try {
-				await ctx.database.set("bridge_message", {
-          from_message_id: bridgeMessage[0].from_message_id,
-        }, {
-          to_message_id: newMessageId[0],
-          onebot_real_message_id: newMessageId[0],
-        })
-			} catch (error) {
-				logger.error(error);
-			}
+	const messageContent = `${avatarElement}[Discord] ${nickname}:\n===== 该条消息为 Discord 编辑后消息 =====\n${content}`;
+	const newMessageId = await sendQQMessageWithRetry(qqbot, bridgeMessage[0].to_channel_id, messageContent);
+	if (newMessageId === null) return;
 
-			break;
-		} catch (error) {
-			retry_count++;
-			if (retry_count >= 3) {
-				logger.error(error);
-				break;
-			}
-
-			logger.info(`发送消息失败，正在重试... (${retry_count}/3)`);
-			await new Promise((resolve) => setTimeout(resolve, 1000));
-		}
+	// Record the message mapping in the database after the message is sent successfully
+	try {
+		await ctx.database.set("bridge_message", {
+			from_message_id: bridgeMessage[0].from_message_id,
+		}, {
+			to_message_id: newMessageId[0],
+			onebot_real_message_id: newMessageId[0],
+		});
+	} catch (error) {
+		logger.error(error);
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,17 +170,21 @@ async function handleQQToDiscord(
     const res = await ctx.http.post(`${webhookUrl}?wait=true`, messageBody.form);
 
     // 消息发送成功后才记录
-    await createBridgeMessageRecord(ctx, {
-      fromMessageId: messageData.id,
-      fromPlatform: platform,
-      fromChannelId: channelId,
-      fromSenderId: sender.id,
-      fromSenderName: nickname,
-      toMessageId: res.id,
-      toPlatform: "discord",
-      toChannelId: to.channel_id,
-      onebotRealMessageId: messageData.id,
-    });
+    try {
+      await createBridgeMessageRecord(ctx, {
+        fromMessageId: messageData.id,
+        fromPlatform: platform,
+        fromChannelId: channelId,
+        fromSenderId: sender.id,
+        fromSenderName: nickname,
+        toMessageId: res.id,
+        toPlatform: "discord",
+        toChannelId: to.channel_id,
+        onebotRealMessageId: messageData.id,
+      });
+    } catch (error) {
+      logger.error(error);
+    }
   } catch (error) {
     logger.error(error);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,336 +1,354 @@
 // @ts-nocheck
-import { Context, h, Session } from 'koishi';
-import { } from 'koishi-plugin-adapter-onebot';
-import { Config } from './config';
-import sharp from 'sharp';
+import { Context, h, Session } from "koishi";
+import { } from "koishi-plugin-adapter-onebot";
+import { Config, BasicType } from "./config";
 
 export * from "./config";
-import { MessageBody } from './types';
-import { convertMsTimestampToISO8601, logger, BlacklistDetector, getBinary, generateMessageBody } from './utils';
-import ProcessorQQ from './qq';
+import { MessageBody } from "./types";
+import { createBridgeMessageRecord, createDiscordAvatarElement, findBridgeRoutes, getDiscordAvatarUrl, sendQQMessageWithRetry } from "./bridge";
+import { convertMsTimestampToISO8601, logger, BlacklistDetector, generateMessageBody } from "./utils";
+import ProcessorQQ from "./qq";
 import { getWebhook } from "./discord/webhook";
-import ProcessorDiscord from './discord';
-import onDiscordMessageDeleted from './discord/message/delete';
-import onDiscordMessageUpdated from './discord/message/update';
+import ProcessorDiscord from "./discord";
+import onDiscordMessageDeleted from "./discord/message/delete";
+import onDiscordMessageUpdated from "./discord/message/update";
 
-export const name = 'bridge-qq-discord';
+export const name = "bridge-qq-discord";
 
-export const inject = ["database"]
+export const inject = ["database"];
+
+function getInitialNickname(session: Session, sender) {
+  if (sender.isBot) return sender.name;
+
+  return "member" in session.event ? session.event.member.nick : sender.name;
+}
+
+function shouldIgnoreMessage(session: Session, sender) {
+  if (!sender) return true;
+  if (sender.id === session.bot.selfId) return true;
+
+  const pattern = /\[QQ:\d+\]/;
+  return pattern.test(sender.name ?? "[QQ:10000]");
+}
+
+async function appendQQQuoteEmbed(
+  ctx: Context,
+  dcBot,
+  messageBody: MessageBody,
+  messageData,
+  elements: h[],
+  channelId: string,
+  selfId: string,
+  blacklist: BlacklistDetector,
+) {
+  if (!("quote" in messageData)) return true;
+
+  // 不同平台之间回复 & 同平台之间回复
+  const diffPlatformQuoteMessage = await ctx.database.get("bridge_message", {
+    to_message_id: messageData.quote.id,
+    to_channel_id: channelId,
+  });
+  const samePlatformQuoteMessage = await ctx.database.get("bridge_message", {
+    from_message_id: messageData.quote.id,
+    from_channel_id: channelId,
+  });
+
+  const quoteMessage = {
+    type: diffPlatformQuoteMessage.length !== 0 ? "diff" : "same",
+    data: diffPlatformQuoteMessage.length !== 0 ? diffPlatformQuoteMessage : samePlatformQuoteMessage,
+  };
+
+  if (quoteMessage.data.length === 0) return true;
+
+  let message = "";
+  let image = {};
+  let source = "";
+
+  switch (quoteMessage.type) {
+    case "same": {
+      source = "to";
+      break;
+    }
+    case "diff": {
+      source = "from";
+      // 删除 QQ 回复时自动带上的 @
+      if (elements[0]?.type === "at" && elements[0].attrs.id === selfId) {
+        elements.shift();
+      }
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+  if (source === "") return false;
+
+  const dcMessage = await dcBot.getMessage(quoteMessage.data[0][`${source}_channel_id`], quoteMessage.data[0][`${source}_message_id`]);
+  if (source === "from") {
+    messageBody.text += `<@${dcMessage.user.id}>`;
+    messageBody.validElement = true;
+  }
+
+  for (const element of dcMessage.elements) {
+    switch (element.type) {
+      case "text": {
+        message += element.attrs.content;
+        break;
+      }
+      case "img": {
+        image = {
+          url: element.attrs.src,
+        };
+        break;
+      }
+      case "face": {
+        message += h.image(element.children[0].attrs.src);
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+  }
+  if (blacklist.check(message)) return false;
+
+  messageBody.embed = [{
+    author: {
+      name: dcMessage.user.nick === null ? dcMessage.user.name : dcMessage.user.nick,
+      icon_url: dcMessage.user.avatar,
+    },
+    timestamp: convertMsTimestampToISO8601(Number(quoteMessage.data[0].timestamp)),
+    description: `${message}\n\n[[ ↑ ]](https://discord.com/channels/${quoteMessage.data[0][`${source}_guild_id`]}/${quoteMessage.data[0][`${source}_channel_id`]}/${dcMessage.id})`,
+    color: 2605017,
+    image,
+  }];
+
+  return true;
+}
+
+async function handleQQToDiscord(
+  ctx: Context,
+  config: Config,
+  session: Session,
+  from: BasicType,
+  to: BasicType,
+  messageData,
+  elements: h[],
+  sender,
+  nickname: string,
+  platform: string,
+  channelId: string,
+  selfId: string,
+  blacklist: BlacklistDetector,
+) {
+  if (nickname === null) nickname = sender.name;
+
+  const dcBot = ctx.bots[`discord:${to.self_id}`];
+  const messageBody = generateMessageBody();
+  const quoteReady = await appendQQQuoteEmbed(ctx, dcBot, messageBody, messageData, elements, channelId, selfId, blacklist);
+  if (!quoteReady) return false;
+
+  const [stop] = await ProcessorQQ.process(elements, session, config, [from, to], ctx, messageBody, blacklist);
+  if (stop || !messageBody.validElement) return false;
+
+  if (nickname === null || nickname === "") nickname = sender.name;
+
+  const [webhookUrl, webhookId, hasWebhook] = await getWebhook(dcBot, to.self_id, to.channel_id);
+  const payloadJson = JSON.stringify({
+    content: messageBody.text,
+    username: `[QQ:${sender.id}] ${nickname}`,
+    avatar_url: sender.avatar,
+    embeds: messageBody.embed,
+    // https://github.com/Cola-Ace/koishi-plugin-bridge-discord-qq/issues/8
+    allowed_mentions: {
+      parse: messageBody.mentionEveryone ? ["everyone"] : [],
+    },
+  });
+  messageBody.form.append("payload_json", payloadJson);
+
+  try {
+    const res = await ctx.http.post(`${webhookUrl}?wait=true`, messageBody.form);
+
+    // 消息发送成功后才记录
+    await createBridgeMessageRecord(ctx, {
+      fromMessageId: messageData.id,
+      fromPlatform: platform,
+      fromChannelId: channelId,
+      fromSenderId: sender.id,
+      fromSenderName: nickname,
+      toMessageId: res.id,
+      toPlatform: "discord",
+      toChannelId: to.channel_id,
+      onebotRealMessageId: messageData.id,
+    });
+  } catch (error) {
+    logger.error(error);
+
+    // 确保文件传输失败时能发送通知
+    if (messageBody.hasFile) {
+      for (let i = 0; i < messageBody.n; i++) {
+        messageBody.form.delete(`files[${i}]`);
+      }
+
+      await ctx.http.post(`${webhookUrl}?wait=true`, messageBody.form);
+    }
+  }
+
+  if (!hasWebhook) {
+    await dcBot.internal.deleteWebhook(webhookId);
+  }
+
+  return true;
+}
+
+async function resolveDiscordQuotePrefix(ctx: Context, config: Config, dcBot, messageData, elements: h[], channelId: string) {
+  let message = "";
+  let quotedMessageId = null;
+
+  if ("quote" in messageData && messageData.content === "") {
+    // 处理转发消息事件和标注消息事件
+    const data = await dcBot.internal.getChannelMessage(channelId, messageData.id);
+
+    if (data.type === 6) return null;
+
+    const guildId = await dcBot.internal.getChannel(messageData.quote.channel.id);
+    const quotedNick = messageData.quote.user.nick === null ? messageData.quote.user.name : messageData.quote.user.nick;
+
+    message += `===== 转发消息 =====\nhttps://discord.com/channels/${guildId.guild_id}/${messageData.quote.channel.id}/${messageData.quote.id}\n===== 以下为转发内容 =====\n${config.show_discord_avatar ? h.image(`${messageData.quote.user.avatar}?size=64`) : ""}${quotedNick.indexOf("[QQ:") !== -1 ? "" : "[Discord] "}${quotedNick}:\n`;
+  }
+
+  if ("quote" in messageData && elements.length !== 0) {
+    // 不同平台之间回复 & 同平台之间回复
+    const diffPlatformQuoteMessage = await ctx.database.get("bridge_message", {
+      to_message_id: messageData.quote.id,
+      to_channel_id: messageData.quote.channel.id,
+    });
+    const samePlatformQuoteMessage = await ctx.database.get("bridge_message", {
+      from_message_id: messageData.quote.id,
+      from_channel_id: messageData.quote.channel.id,
+    });
+
+    const quoteMessage = diffPlatformQuoteMessage.length !== 0 ? diffPlatformQuoteMessage : samePlatformQuoteMessage;
+
+    if (quoteMessage.length !== 0) {
+      quotedMessageId = quoteMessage[0].onebot_real_message_id;
+    }
+  }
+
+  return { message, quotedMessageId };
+}
+
+async function handleDiscordToQQ(
+  ctx: Context,
+  config: Config,
+  session: Session,
+  from: BasicType,
+  to: BasicType,
+  messageData,
+  elements: h[],
+  sender,
+  nickname: string,
+  platform: string,
+  channelId: string,
+  blacklist: BlacklistDetector,
+) {
+  const qqbot = ctx.bots[`${to.platform}:${to.self_id}`];
+  const dcBot = ctx.bots[`discord:${from.self_id}`];
+  const quotePrefix = await resolveDiscordQuotePrefix(ctx, config, dcBot, messageData, elements, channelId);
+  if (quotePrefix === null) return false;
+
+  let { message, quotedMessageId } = quotePrefix;
+
+  // 处理消息元素
+  message = await ProcessorDiscord.process(elements, config, [from, to], ctx, message, messageData, dcBot, qqbot, blacklist);
+
+  // https://github.com/Cola-Ace/koishi-plugin-bridge-discord-qq/issues/6
+  if (!sender.isBot) {
+    const member = await dcBot.internal.getGuildMember(session.guildId, sender.id);
+    nickname = member.nick === null ? member.user.global_name : member.nick;
+  }
+
+  const avatar = getDiscordAvatarUrl(config, sender.avatar, `${sender.avatar}?size=64`);
+  const avatarElement = await createDiscordAvatarElement(ctx, config, avatar);
+  if (avatarElement === null) return false;
+
+  let channelInfo = null;
+  if (config.show_discord_channel_name) {
+    try {
+      channelInfo = await dcBot.internal.getChannel(channelId);
+    } catch (e) {
+      logger.error(`Failed to get channel info: ${e}`);
+    }
+  }
+
+  let prefix = "[Discord]";
+  if (config.show_discord_channel_name && channelInfo !== null) {
+    prefix = `[Discord from ${channelInfo.name ?? ""}]`;
+  }
+
+  const messageContent = `${quotedMessageId === null ? "" : h.quote(quotedMessageId)}${avatarElement}${prefix} ${nickname}:\n${message}`;
+  const messageId = await sendQQMessageWithRetry(qqbot, to.channel_id, messageContent);
+  if (messageId === null) return true;
+
+  // Record the message mapping in the database after the message is sent successfully
+  try {
+    await createBridgeMessageRecord(ctx, {
+      fromMessageId: messageData.id,
+      fromPlatform: platform,
+      fromChannelId: channelId,
+      fromSenderId: sender.id,
+      fromSenderName: nickname,
+      toMessageId: messageId[0],
+      toPlatform: "onebot",
+      toChannelId: to.channel_id,
+      onebotRealMessageId: messageId[0],
+    });
+  } catch (error) {
+    logger.error(error);
+  }
+
+  return true;
+}
 
 const main = async (ctx: Context, config: Config, session: Session) => {
   const sender = session.event.user;
-  if (!sender) return; // 避免 sender 为空导致的错误
-
-  if (sender.id === session.bot.selfId) return; // 避免回环
-
-  const pattern = /\[QQ:\d+\]/;
-  if (pattern.test(sender.name ?? "[QQ:10000]")) return; // 不转发自己消息
+  if (shouldIgnoreMessage(session, sender)) return;
 
   const platform = session.event.platform;
-  const self_id = session.event.selfId;
-  const channel_id = session.event.channel.id;
-  const message_data = session.event.message;
-
-  const Blacklist = new BlacklistDetector(config.words_blacklist);
+  const selfId = session.event.selfId;
+  const channelId = session.event.channel.id;
+  const messageData = session.event.message;
+  const blacklist = new BlacklistDetector(config.words_blacklist);
 
   // 测试用
   if (config.debug) {
     logger.info("-------Message-------");
-    logger.info(message_data);
+    logger.info(messageData);
     logger.info("-------Sender-------");
     logger.info(sender);
     logger.info("-------End--------");
   }
 
   // 如果 message_data 不包含 id 字段，则代表该消息为 QQ 文件的占位符消息，直接跳过
-  if (!(message_data && "id" in message_data)) return;
+  if (!(messageData && "id" in messageData)) return;
 
-  let nickname = sender.isBot ? sender.name : ("member" in session.event ? session.event.member.nick : sender.name); // 判断是否为 bot
+  let nickname = getInitialNickname(session, sender);
+  const elements = messageData.elements ?? [];
 
-  // const elements = message_data.elements.filter(element => element.type !== "at"); // 确保没有@格式
-  const elements = message_data.elements ?? [];
+  if (elements.length <= 0 && !Object.keys(messageData).includes("quote")) return;
 
-  if (elements.length <= 0 && !Object.keys(message_data).includes("quote")) return;
+  for (const { from, to } of findBridgeRoutes(config, platform, selfId, channelId)) {
+    try {
+      const shouldContinue = to.platform === "discord"
+        ? await handleQQToDiscord(ctx, config, session, from, to, messageData, elements, sender, nickname, platform, channelId, selfId, blacklist)
+        : await handleDiscordToQQ(ctx, config, session, from, to, messageData, elements, sender, nickname, platform, channelId, blacklist);
 
-  for (const constant of config.constant) {
-    if (!constant.enable) continue;
-
-    for (const from of constant.from) {
-      if (from.platform === platform && from.self_id === self_id && from.channel_id === channel_id) {
-        for (const to of constant.to) {
-          try {
-            if (to.platform === "discord") {
-              // QQ -> Discord
-              if (nickname === null) nickname = sender.name; // 如果群昵称为空则使用用户名
-
-              const dc_bot = ctx.bots[`discord:${to.self_id}`];
-
-              const message_body: MessageBody = generateMessageBody();
-
-              if ("quote" in message_data) {
-                // 不同平台之间回复 & 同平台之间回复
-                const diff_platform_quote_message = await ctx.database.get("bridge_message", {
-                  to_message_id: message_data.quote.id,
-                  to_channel_id: channel_id
-                })
-                const same_platform_quote_message = await ctx.database.get("bridge_message", {
-                  from_message_id: message_data.quote.id,
-                  from_channel_id: channel_id
-                });
-
-                const quote_message = { type: diff_platform_quote_message.length !== 0 ? "diff" : "same", data: diff_platform_quote_message.length !== 0 ? diff_platform_quote_message : same_platform_quote_message };
-
-                if (quote_message.data.length !== 0) {
-                  let message = "";
-                  let image = {};
-                  let source = "";
-
-                  switch (quote_message["type"]) {
-                    case "same": { // 同平台之间回复
-                      source = "to";
-                      break;
-                    }
-                    case "diff": { // 不同平台之间回复
-                      source = "from"
-                      // 删除 QQ 回复时自动带上的 @
-                      if (elements[0].type === "at" && elements[0].attrs.id === self_id) {
-                        elements.shift();
-                      }
-                      break;
-                    }
-                    default: {
-                      break;
-                    }
-                  }
-                  if (source === "") return;
-
-                  const dc_message = await dc_bot.getMessage(quote_message["data"][0][`${source}_channel_id`], quote_message["data"][0][`${source}_message_id`]);
-                  if (source === "from"){
-                    message_body.text += `<@${dc_message.user.id}>`;
-                    message_body.validElement = true;
-                  }
-
-                  for (const element of dc_message.elements) {
-                    switch (element.type) {
-                      case "text": {
-                        message += element.attrs.content;
-                        break;
-                      }
-                      case "img": {
-                        image = {
-                          url: element.attrs.src
-                        }
-                        break;
-                      }
-                      case "face": {
-                        message += h.image(element.children[0].attrs.src);
-                        break;
-                      }
-                      default: {
-                        break;
-                      }
-                    }
-                  }
-                  if (Blacklist.check(message)) return; // 黑名单检测
-                  message_body.embed = [{
-                    author: {
-                      name: (dc_message["user"]["nick"] === null ? dc_message["user"]["name"] : dc_message["user"]["nick"]),
-                      icon_url: dc_message["user"]["avatar"]
-                    },
-                    timestamp: convertMsTimestampToISO8601(Number(quote_message["data"][0]["timestamp"])),
-                    description: `${message}\n\n[[ ↑ ]](https://discord.com/channels/${quote_message["data"][0][`${source}_guild_id`]}/${quote_message["data"][0][`${source}_channel_id`]}/${dc_message.id})`,
-                    color: 2605017,
-                    image
-                  }]
-                }
-              }
-
-              const [stop, _] = await ProcessorQQ.process(elements, session, config, [from, to], ctx, message_body, Blacklist);
-              if (stop || !message_body.validElement) return;
-
-              // 实现发送消息功能
-              if (nickname === null || nickname === "") nickname = sender.name;
-
-              const [webhook_url, webhook_id, hasWebhook] = await getWebhook(dc_bot, to.self_id, to.channel_id);
-
-              const payload_json = JSON.stringify({
-                content: message_body.text,
-                username: `[QQ:${sender.id}] ${nickname}`,
-                avatar_url: sender.avatar,
-                embeds: message_body.embed,
-                // https://github.com/Cola-Ace/koishi-plugin-bridge-discord-qq/issues/8
-                allowed_mentions: {
-                  parse: (message_body.mentionEveryone ? ["everyone"] : []),
-                },
-              });
-              message_body.form.append("payload_json", payload_json);
-
-              try {
-                const res = await ctx.http.post(`${webhook_url}?wait=true`, message_body.form);
-                const from_guild_id = await ctx.database.get("channel", {
-                  id: channel_id
-                });
-                const to_guild_id = await ctx.database.get("channel", {
-                  id: to.channel_id
-                });
-
-                // 消息发送成功后才记录
-                await ctx.database.create("bridge_message", {
-                  timestamp: BigInt(Date.now()),
-                  from_message_id: message_data.id,
-                  from_platform: platform,
-                  from_channel_id: channel_id,
-                  from_guild_id: from_guild_id[0]["guildId"],
-                  from_sender_id: sender.id,
-                  from_sender_name: nickname,
-                  to_message_id: res.id,
-                  to_platform: "discord",
-                  to_channel_id: to.channel_id,
-                  to_guild_id: to_guild_id[0]["guildId"],
-                  onebot_real_message_id: message_data.id
-                })
-              } catch (error) {
-                logger.error(error);
-
-                // 确保文件传输失败时能发送通知
-                if (message_body.hasFile) {
-                  for (let i = 0; i < message_body.n; i++) {
-                    message_body.form.delete(`files[${i}]`);
-                  }
-
-                  await ctx.http.post(`${webhook_url}?wait=true`, message_body.form);
-                }
-              }
-
-              if (!hasWebhook) {
-                await dc_bot.internal.deleteWebhook(webhook_id);
-              }
-
-              continue;
-            }
-
-            // Discord -> QQ
-            const qqbot = ctx.bots[`${to.platform}:${to.self_id}`];
-            const dc_bot = ctx.bots[`discord:${from.self_id}`];
-
-            let message = "";
-            let quoted_message_id = null;
-
-            if ("quote" in message_data && message_data.content === "") { // 处理转发消息事件和标注消息事件
-              const data = await dc_bot.internal.getChannelMessage(channel_id, message_data.id);
-
-              if (data.type === 6) return; // Discord 标注消息事件
-
-              const guild_id = await dc_bot.internal.getChannel(message_data.quote.channel.id);
-              const quoted_nick = message_data.quote.user.nick === null ? message_data.quote.user.name : message_data.quote.user.nick;
-
-              message += `===== 转发消息 =====\nhttps://discord.com/channels/${guild_id["guild_id"]}/${message_data.quote.channel.id}/${message_data.quote.id}\n===== 以下为转发内容 =====\n${config.show_discord_avatar ? h.image(`${message_data.quote.user.avatar}?size=64`) : ""}${quoted_nick.indexOf("[QQ:") !== -1 ? "" : "[Discord] "}${quoted_nick}:\n`;
-            }
-
-            if ("quote" in message_data && elements.length !== 0) {
-              // 不同平台之间回复 & 同平台之间回复
-              const diff_platform_quote_message = await ctx.database.get("bridge_message", {
-                to_message_id: message_data.quote.id,
-                to_channel_id: message_data.quote.channel.id
-              })
-              const same_platform_quote_message = await ctx.database.get("bridge_message", {
-                from_message_id: message_data.quote.id,
-                from_channel_id: message_data.quote.channel.id
-              });
-
-              const quote_message = diff_platform_quote_message.length !== 0 ? diff_platform_quote_message : same_platform_quote_message;
-
-              if (quote_message.length !== 0) {
-                quoted_message_id = quote_message[0]["onebot_real_message_id"];
-              }
-            }
-
-            // 处理消息元素
-            message = await ProcessorDiscord.process(elements, config, [from, to], ctx, message, message_data, dc_bot, qqbot, Blacklist);
-
-            // https://github.com/Cola-Ace/koishi-plugin-bridge-discord-qq/issues/6
-            if (!sender.isBot) {
-              const member = await dc_bot.internal.getGuildMember(session.guildId, sender.id);
-              // nickname = sender.nick === null ? sender.name : sender.nick;
-              nickname = member.nick === null ? member.user.global_name : member.nick;
-            }
-
-            // Process Discord default avatar
-            let avatar_color = "";
-            let avatar = `${sender.avatar}?size=64`;
-            if (sender.avatar === null) {
-              avatar_color = config.discord_default_avatar_color.toString();
-              if (config.discord_default_avatar_color === 99){
-                avatar_color = Math.floor(Math.random() * 5).toString();
-              }
-              avatar = `https://cdn.discordapp.com/embed/avatars/${avatar_color}.png`;
-            }
-
-            // https://github.com/Cola-Ace/koishi-plugin-bridge-discord-qq/issues/7
-            // const avatar = sender.avatar === null ? "https://cdn.discordapp.com/embed/avatars/0.png" : `${sender.avatar}?size=64`;
-
-            let message_content = `${quoted_message_id === null ? "" : h.quote(quoted_message_id)}${config.show_discord_avatar ? h.image(avatar) : ""}[Discord] ${nickname}:\n${message}`;
-            if (config.file_processor === "Koishi") {
-              const [avatar_blob, avatar_type, avatar_error] = await getBinary(avatar, ctx.http);
-              if (avatar_error) {
-                logger.error(avatar_error);
-                return;
-              }
-              const avatar_arrayBuffer = await avatar_blob.arrayBuffer();
-              const avatar_resize_arrayBuffer = await sharp(avatar_arrayBuffer).resize(64, 64).toBuffer();
-              message_content = `${quoted_message_id === null ? "" : h.quote(quoted_message_id)}${config.show_discord_avatar ? h.image(avatar_resize_arrayBuffer, avatar_type) : ""}[Discord] ${nickname}:\n${message}`;
-            }
-
-            let retry_count = 0;
-            while (retry_count <= 3){
-              try {
-                const message_id = await qqbot.sendMessage(to.channel_id, message_content);
-                const from_guild_id = await ctx.database.get("channel", {
-                  id: channel_id
-                });
-                const to_guild_id = await ctx.database.get("channel", {
-                  id: to.channel_id
-                });
-                // Record the message mapping in the database after the message is sent successfully
-                try {
-                  await ctx.database.create("bridge_message", {
-                    timestamp: BigInt(Date.now()),
-                    from_message_id: message_data.id,
-                    from_platform: platform,
-                    from_channel_id: channel_id,
-                    from_guild_id: from_guild_id[0]["guildId"],
-                    from_sender_id: sender.id,
-                    from_sender_name: nickname,
-                    to_message_id: message_id[0],
-                    to_platform: "onebot",
-                    to_channel_id: to.channel_id,
-                    to_guild_id: to_guild_id[0]["guildId"],
-                    onebot_real_message_id: message_id[0]
-                  })
-                } catch (error) {
-                  logger.error(error);
-                }
-
-                break;
-              } catch (error) {
-                retry_count++;
-                if (retry_count >= 3) {
-                  logger.error(error);
-                  break;
-                }
-
-                logger.info(`发送消息失败，正在重试... (${retry_count}/3)`);
-                await new Promise(resolve => setTimeout(resolve, 1000));
-              }
-            }
-          } catch (error) {
-            logger.error(error);
-          }
-        }
-      }
+      if (!shouldContinue) return;
+    } catch (error) {
+      logger.error(error);
     }
   }
-}
+};
 
 export function apply(ctx: Context, config: Config) {
   ctx.model.extend("bridge_message", {
@@ -346,15 +364,15 @@ export function apply(ctx: Context, config: Config) {
     to_platform: "string",
     to_channel_id: "string",
     to_guild_id: "string",
-    onebot_real_message_id: "string"
+    onebot_real_message_id: "string",
   }, {
     primary: "id",
-    autoInc: true
-  })
+    autoInc: true,
+  });
 
-  ctx.on("message", async (session) => await main(ctx, config, session));
+  ctx.on("message", async session => await main(ctx, config, session));
 
   // for Discord
-  ctx.on("discord/message-update", async (session) => await onDiscordMessageUpdated(ctx, config, session));
-  ctx.on("discord/message-delete", async (session) => await onDiscordMessageDeleted(ctx, config, session));
+  ctx.on("discord/message-update", async session => await onDiscordMessageUpdated(ctx, config, session));
+  ctx.on("discord/message-delete", async session => await onDiscordMessageDeleted(ctx, config, session));
 }


### PR DESCRIPTION
## Summary
- 将 `main()` 拆分为模块化函数 (`handleDiscordToQQ`, `handleQQToDiscord` 等)，提取公共桥接逻辑到 `src/bridge.ts`
- 新增 `show_discord_channel_name` 配置项，控制转发消息到 QQ 时是否显示 Discord 频道名称
- 将 `lib/` 加入 `.gitignore`
- 版本号升至 1.9.1

## Test plan
- [x] 开启配置后，Discord 消息转发到 QQ 时显示频道名称
- [x] 关闭配置后，行为与之前一致