### PR TITLE
fix: use data urls for discord media forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.9.2
+
+### 🐞 Bug Fixes
+- [Discord -> QQ] 使用 `data:` URL 转发 Koishi 处理的图片、表情、视频和头像，避免 `base64:` 协议弃用提示。
+
+## 1.9.1
+
 ### ✨ Features
 - [Config] 新增了 `show_discord_channel_name` 用于控制转发消息到 QQ 时是否显示 Discord 的频道名称（默认关闭）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 1.9.2
+### ✨ Features
+- None
 
 ### 🐞 Bug Fixes
 - [Discord -> QQ] 使用 `data:` URL 转发 Koishi 处理的图片、表情、视频和头像，避免 `base64:` 协议弃用提示

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,4 @@
 ## 1.9.2
 
 ### 🐞 Bug Fixes
-- [Discord -> QQ] 使用 `data:` URL 转发 Koishi 处理的图片、表情、视频和头像，避免 `base64:` 协议弃用提示。
-
-## 1.9.1
-
-### ✨ Features
-- [Config] 新增了 `show_discord_channel_name` 用于控制转发消息到 QQ 时是否显示 Discord 的频道名称（默认关闭）
-
-### 🐞 Bug Fixes
-- None
+- [Discord -> QQ] 使用 `data:` URL 转发 Koishi 处理的图片、表情、视频和头像，避免 `base64:` 协议弃用提示

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-bridge-qq-discord",
   "description": "自用插件，如需进一步了解请联系我（联系方式见 Github）",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "contributors": [
     "Xc_ace <xca259@gmail.com>"
   ],

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,7 +1,7 @@
 import { Bot, Context, h } from "koishi";
 import sharp from "sharp";
 import { BasicType, Config } from "./config";
-import { getBinary, logger } from "./utils";
+import { getBinary, logger, toDataUrl } from "./utils";
 
 export interface BridgeRoute {
   from: BasicType;
@@ -109,7 +109,7 @@ export async function createDiscordAvatarElement(ctx: Context, config: Config, a
   const avatarArrayBuffer = await avatarBlob.arrayBuffer();
   const resizedAvatar = await sharp(avatarArrayBuffer).resize(64, 64).toBuffer();
 
-  return h.image(resizedAvatar, avatarType);
+  return h.image(toDataUrl(resizedAvatar, avatarType));
 }
 
 export function findDiscordToQQBot(ctx: Context, config: Config, fromChannelId: string, toChannelId: string): Bot | null {

--- a/src/discord/index.ts
+++ b/src/discord/index.ts
@@ -1,6 +1,6 @@
 import { Bot, Context, h } from "koishi";
 import type { Session } from "koishi";
-import { getBinary, logger, BlacklistDetector } from "../utils";
+import { getBinary, logger, BlacklistDetector, toDataUrl } from "../utils";
 import { Config, BasicType } from "../config";
 
 import { URL } from "url";
@@ -56,13 +56,13 @@ export default class ProcessorDiscord {
 
 				case "img": {
 					if (config.file_processor === "Koishi") {
-						const [img_blob, _, img_error] = await getBinary(element.attrs.src, ctx.http);
+						const [img_blob, img_type, img_error] = await getBinary(element.attrs.src, ctx.http);
 						if (img_error) {
 							logger.error(img_error);
 							break;
 						}
 						const img_arrayBuffer = await img_blob.arrayBuffer();
-						message += h.image(img_arrayBuffer, element.attrs.type);
+						message += h.image(toDataUrl(img_arrayBuffer, img_type));
 					} else {
 						message += h.image(element.attrs.src);
 					}
@@ -75,13 +75,13 @@ export default class ProcessorDiscord {
           const url = `${src}${src.indexOf("?quality=lossless") !== -1 ? "&size=44" : ""}`
 
           if (config.file_processor === "Koishi") {
-						const [img_blob, _, img_error] = await getBinary(url, ctx.http);
+						const [img_blob, img_type, img_error] = await getBinary(url, ctx.http);
 						if (img_error) {
 							logger.error(img_error);
 							break;
 						}
 						const img_arrayBuffer = await img_blob.arrayBuffer();
-						message += h.image(img_arrayBuffer, element.attrs.type);
+						message += h.image(toDataUrl(img_arrayBuffer, img_type));
 					} else {
 						message += h.image(url);
 					}
@@ -118,13 +118,13 @@ export default class ProcessorDiscord {
 					}
 
 					if (config.file_processor === "Koishi") {
-						const [video_blob, _, video_error] = await getBinary(element.attrs.src, ctx.http);
+						const [video_blob, video_type, video_error] = await getBinary(element.attrs.src, ctx.http);
 						if (video_error) {
 							logger.error(video_error);
 							break;
 						}
 						const video_arrayBuffer = await video_blob.arrayBuffer();
-						message += h.video(video_arrayBuffer, element.attrs.type);
+						message += h.video(toDataUrl(video_arrayBuffer, video_type));
 					} else {
 						message += h.video(element.attrs.src);
 					}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
-import { Logger, HTTP } from 'koishi';
-import { MessageBody } from './types';
+import { Buffer } from "buffer";
+import { Logger, HTTP } from "koishi";
+import { MessageBody } from "./types";
 
 export const logger = new Logger("bridge");
 export function convertMsTimestampToISO8601(msTimestamp: number): string {
@@ -21,6 +22,10 @@ export function generateMessageBody(): MessageBody {
     hasFile: false,
     mentionEveryone: false
   };
+}
+
+export function toDataUrl(data: ArrayBuffer | Uint8Array, type?: string | null): string {
+  return `data:${type ?? ""};base64,${Buffer.from(data).toString("base64")}`;
 }
 
 export function getDate() {


### PR DESCRIPTION
replace binary Koishi media elements with data: URLs for Discord-to-QQ forwarding, including images, stickers, videos, and resized avatars.