### PR TITLE
fix: handle Discord thread bridge routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,6 @@
 - None
 
 ### 🐞 Bug Fixes
-- [Discord -> QQ] 使用 `data:` URL 转发 Koishi 处理的图片、表情、视频和头像，避免 `base64:` 协议弃用提示
+- [Discord -> QQ] 支持 Discord thread 消息按父频道配置转发，并在 QQ 消息中标记来源 thread
+- [Discord -> QQ] 不再转发 private thread 消息
+- [Discord -> QQ] 过滤 Discord 创建、删除子区等系统消息，避免把子区名称转发到 QQ

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-bridge-qq-discord",
   "description": "自用插件，如需进一步了解请联系我（联系方式见 Github）",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "contributors": [
     "Xc_ace <xca259@gmail.com>"
   ],

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -52,6 +52,19 @@ export function isBridgeableDiscordMessage(message): boolean {
   return [0, 19].includes(Number(message.type));
 }
 
+export async function isBridgeableDiscordChannelMessage(ctx: Context, selfId: string, channelId: string, message): Promise<boolean> {
+  if (!isBridgeableDiscordMessage(message)) return false;
+  if (message?.type !== undefined) return true;
+
+  try {
+    const data = await ctx.bots[`discord:${selfId}`].internal.getChannelMessage(channelId, message.id);
+    return isBridgeableDiscordMessage(data);
+  } catch (error) {
+    logger.error(error);
+    return true;
+  }
+}
+
 export async function resolveDiscordRouteChannel(ctx: Context, config: Config, platform: string, selfId: string, channelId: string): Promise<DiscordRouteChannel> {
   if (platform !== "discord") return { routeChannelId: channelId };
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -20,6 +20,15 @@ export interface BridgeMessageRecord {
   onebotRealMessageId: string;
 }
 
+export interface DiscordRouteChannel {
+  routeChannelId: string;
+  thread?: {
+    id: string;
+    name: string;
+    parentName?: string;
+  };
+}
+
 export function findBridgeRoutes(config: Config, platform: string, selfId: string, channelId: string): BridgeRoute[] {
   const routes: BridgeRoute[] = [];
 
@@ -36,6 +45,45 @@ export function findBridgeRoutes(config: Config, platform: string, selfId: strin
   }
 
   return routes;
+}
+
+export async function resolveDiscordRouteChannel(ctx: Context, config: Config, platform: string, selfId: string, channelId: string): Promise<DiscordRouteChannel> {
+  if (platform !== "discord") return { routeChannelId: channelId };
+
+  const dcBot = ctx.bots[`discord:${selfId}`];
+  let channel;
+  try {
+    channel = await dcBot.internal.getChannel(channelId);
+  } catch (error) {
+    logger.error(error);
+    return { routeChannelId: channelId };
+  }
+  const channelType = Number(channel.type);
+  if (channelType === 12) return { routeChannelId: "" };
+  if (findBridgeRoutes(config, platform, selfId, channelId).length > 0) return { routeChannelId: channelId };
+  if (![10, 11].includes(channelType) || !channel.parent_id) return { routeChannelId: channelId };
+
+  const routes = findBridgeRoutes(config, platform, selfId, channel.parent_id);
+  if (routes.length === 0) return { routeChannelId: channelId };
+
+  let parentName: string | undefined;
+  if (config.show_discord_channel_name) {
+    try {
+      const parent = await dcBot.internal.getChannel(channel.parent_id);
+      parentName = parent.name ?? channel.parent_id;
+    } catch (error) {
+      logger.error(error);
+    }
+  }
+
+  return {
+    routeChannelId: channel.parent_id,
+    thread: {
+      id: channelId,
+      name: channel.name ?? channelId,
+      parentName,
+    },
+  };
 }
 
 export async function createBridgeMessageRecord(ctx: Context, record: BridgeMessageRecord) {
@@ -112,16 +160,29 @@ export async function createDiscordAvatarElement(ctx: Context, config: Config, a
   return h.image(toDataUrl(resizedAvatar, avatarType));
 }
 
-export function findDiscordToQQBot(ctx: Context, config: Config, fromChannelId: string, toChannelId: string): Bot | null {
+export async function findDiscordToQQBot(ctx: Context, config: Config, fromChannelId: string, toChannelId: string): Promise<Bot | null> {
   for (const constant of config.constant ?? []) {
     if (!constant.enable) continue;
 
     for (const from of constant.from) {
-      if (from.platform !== "discord" || from.channel_id !== fromChannelId) continue;
+      if (from.platform !== "discord") continue;
 
       for (const to of constant.to) {
         if (to.platform === "onebot" && to.channel_id === toChannelId) {
-          return ctx.bots[`${to.platform}:${to.self_id}`];
+          const dcBot = ctx.bots[`discord:${from.self_id}`];
+          let channel;
+          try {
+            channel = await dcBot.internal.getChannel(fromChannelId);
+          } catch (error) {
+            logger.error(error);
+            continue;
+          }
+          const channelType = Number(channel.type);
+          if (channelType === 12) continue;
+          if (from.channel_id === fromChannelId) return ctx.bots[`${to.platform}:${to.self_id}`];
+          if ([10, 11].includes(channelType) && channel.parent_id === from.channel_id) {
+            return ctx.bots[`${to.platform}:${to.self_id}`];
+          }
         }
       }
     }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -47,6 +47,11 @@ export function findBridgeRoutes(config: Config, platform: string, selfId: strin
   return routes;
 }
 
+export function isBridgeableDiscordMessage(message): boolean {
+  if (message?.type === undefined) return true;
+  return [0, 19].includes(Number(message.type));
+}
+
 export async function resolveDiscordRouteChannel(ctx: Context, config: Config, platform: string, selfId: string, channelId: string): Promise<DiscordRouteChannel> {
   if (platform !== "discord") return { routeChannelId: channelId };
 

--- a/src/discord/message/delete.ts
+++ b/src/discord/message/delete.ts
@@ -21,7 +21,7 @@ export default async function onDiscordMessageDeleted(ctx: Context, config: Conf
   // or the message was not bridged for some reason (for example have words in the blacklist). In this case, we can just ignore the deletion.
   if (bridgeMessage.length === 0) return;
 
-  const qqbot = findDiscordToQQBot(ctx, config, channelId, bridgeMessage[0].to_channel_id);
+  const qqbot = await findDiscordToQQBot(ctx, config, channelId, bridgeMessage[0].to_channel_id);
   if (!qqbot) return;
 
   // Delete message

--- a/src/discord/message/update.ts
+++ b/src/discord/message/update.ts
@@ -30,7 +30,7 @@ export default async function onDiscordMessageUpdated(ctx: Context, config: Conf
 	// or the message was not bridged for some reason (for example have words in the blacklist). In this case, we can just ignore the update.
 	if (bridgeMessage.length === 0) return;
 
-	const qqbot = findDiscordToQQBot(ctx, config, channelId, bridgeMessage[0].to_channel_id);
+	const qqbot = await findDiscordToQQBot(ctx, config, channelId, bridgeMessage[0].to_channel_id);
 	if (!qqbot) return;
 
 	// Delete message

--- a/src/discord/message/update.ts
+++ b/src/discord/message/update.ts
@@ -1,12 +1,13 @@
 // @ts-nocheck
 import { Context } from "koishi";
 import type { Session } from "koishi";
-import { createDiscordAvatarElement, findDiscordToQQBot, getDiscordAvatarUrl, sendQQMessageWithRetry } from "../../bridge";
+import { createDiscordAvatarElement, findDiscordToQQBot, getDiscordAvatarUrl, isBridgeableDiscordMessage, sendQQMessageWithRetry } from "../../bridge";
 import { logger, BlacklistDetector } from "../../utils";
 import { Config } from "../../config";
 
 export default async function onDiscordMessageUpdated(ctx: Context, config: Config, session: Session) {
 	if (!config.sync_edit_delete) return;
+	if (!isBridgeableDiscordMessage(session)) return;
 
 	// TODO: parse new format message
 	const content = session.content;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { Config, BasicType } from "./config";
 
 export * from "./config";
 import { MessageBody } from "./types";
-import { createBridgeMessageRecord, createDiscordAvatarElement, findBridgeRoutes, getDiscordAvatarUrl, resolveDiscordRouteChannel, sendQQMessageWithRetry } from "./bridge";
+import { createBridgeMessageRecord, createDiscordAvatarElement, findBridgeRoutes, getDiscordAvatarUrl, isBridgeableDiscordMessage, resolveDiscordRouteChannel, sendQQMessageWithRetry } from "./bridge";
 import { convertMsTimestampToISO8601, logger, BlacklistDetector, generateMessageBody } from "./utils";
 import ProcessorQQ from "./qq";
 import { getWebhook } from "./discord/webhook";
@@ -340,6 +340,7 @@ const main = async (ctx: Context, config: Config, session: Session) => {
 
   // 如果 message_data 不包含 id 字段，则代表该消息为 QQ 文件的占位符消息，直接跳过
   if (!(messageData && "id" in messageData)) return;
+  if (platform === "discord" && !isBridgeableDiscordMessage(messageData)) return;
 
   let nickname = getInitialNickname(session, sender);
   const elements = messageData.elements ?? [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { Config, BasicType } from "./config";
 
 export * from "./config";
 import { MessageBody } from "./types";
-import { createBridgeMessageRecord, createDiscordAvatarElement, findBridgeRoutes, getDiscordAvatarUrl, sendQQMessageWithRetry } from "./bridge";
+import { createBridgeMessageRecord, createDiscordAvatarElement, findBridgeRoutes, getDiscordAvatarUrl, resolveDiscordRouteChannel, sendQQMessageWithRetry } from "./bridge";
 import { convertMsTimestampToISO8601, logger, BlacklistDetector, generateMessageBody } from "./utils";
 import ProcessorQQ from "./qq";
 import { getWebhook } from "./discord/webhook";
@@ -254,6 +254,7 @@ async function handleDiscordToQQ(
   nickname: string,
   platform: string,
   channelId: string,
+  thread,
   blacklist: BlacklistDetector,
 ) {
   const qqbot = ctx.bots[`${to.platform}:${to.self_id}`];
@@ -286,7 +287,11 @@ async function handleDiscordToQQ(
   }
 
   let prefix = "[Discord]";
-  if (config.show_discord_channel_name && channelInfo !== null) {
+  if (thread) {
+    prefix = config.show_discord_channel_name && thread.parentName
+      ? `[Discord from ${thread.parentName} -> thread ${thread.name}]`
+      : `[Discord from thread ${thread.name}]`;
+  } else if (config.show_discord_channel_name && channelInfo !== null) {
     prefix = `[Discord from ${channelInfo.name ?? ""}]`;
   }
 
@@ -341,11 +346,13 @@ const main = async (ctx: Context, config: Config, session: Session) => {
 
   if (elements.length <= 0 && !Object.keys(messageData).includes("quote")) return;
 
-  for (const { from, to } of findBridgeRoutes(config, platform, selfId, channelId)) {
+  const routeChannel = await resolveDiscordRouteChannel(ctx, config, platform, selfId, channelId);
+
+  for (const { from, to } of findBridgeRoutes(config, platform, selfId, routeChannel.routeChannelId)) {
     try {
       const shouldContinue = to.platform === "discord"
         ? await handleQQToDiscord(ctx, config, session, from, to, messageData, elements, sender, nickname, platform, channelId, selfId, blacklist)
-        : await handleDiscordToQQ(ctx, config, session, from, to, messageData, elements, sender, nickname, platform, channelId, blacklist);
+        : await handleDiscordToQQ(ctx, config, session, from, to, messageData, elements, sender, nickname, platform, channelId, routeChannel.thread, blacklist);
 
       if (!shouldContinue) return;
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { Config, BasicType } from "./config";
 
 export * from "./config";
 import { MessageBody } from "./types";
-import { createBridgeMessageRecord, createDiscordAvatarElement, findBridgeRoutes, getDiscordAvatarUrl, isBridgeableDiscordMessage, resolveDiscordRouteChannel, sendQQMessageWithRetry } from "./bridge";
+import { createBridgeMessageRecord, createDiscordAvatarElement, findBridgeRoutes, getDiscordAvatarUrl, isBridgeableDiscordChannelMessage, resolveDiscordRouteChannel, sendQQMessageWithRetry } from "./bridge";
 import { convertMsTimestampToISO8601, logger, BlacklistDetector, generateMessageBody } from "./utils";
 import ProcessorQQ from "./qq";
 import { getWebhook } from "./discord/webhook";
@@ -340,7 +340,7 @@ const main = async (ctx: Context, config: Config, session: Session) => {
 
   // 如果 message_data 不包含 id 字段，则代表该消息为 QQ 文件的占位符消息，直接跳过
   if (!(messageData && "id" in messageData)) return;
-  if (platform === "discord" && !isBridgeableDiscordMessage(messageData)) return;
+  if (platform === "discord" && !await isBridgeableDiscordChannelMessage(ctx, selfId, channelId, messageData)) return;
 
   let nickname = getInitialNickname(session, sender);
   const elements = messageData.elements ?? [];


### PR DESCRIPTION
## Summary
- bridge Discord public/announcement thread messages through parent channel routes
- skip private thread messages
- ignore Discord system messages for thread create/delete events
- bump version to 1.9.3 and update changelog

## Verification
- yakumo esbuild
- yakumo tsc
- git diff --check